### PR TITLE
blitted the name of the policy to the bottom left

### DIFF
--- a/drawer.py
+++ b/drawer.py
@@ -85,13 +85,15 @@ class Drawer:
         self.DrawHistoryQueue(surface, histref, y_lerp_offset, player_pixel_loc)
         self.DrawPlayerDot(surface, player_pixel_loc)
 
-    # draw text onto input surface
-    def DrawText(self, surface, text):
-        textSurface = self.font.render(text, 1, (200, 0, 0), (255,255,255)) # red text color, white background
-        surface.blit(textSurface, (0, 0))
+    # draw policy name onto the surface
+    def DrawPolicyName(self, surface, name):
+        policyName = " " + name + " "
+        textSurface = self.font.render(policyName, 1, (200, 0, 0), (255,255,255)) # red text color, white background
+        surface.blit(textSurface, (0, 297)) # place the total number of collisions on the top left
 
     # draw total number of collisions onto the surface
-    def DrawTotalCollisions(self, name, surface, total_collisions):
-        collisionStatement = "  " + name + " - Total Collisions: " + str(total_collisions) + "  "
-        self.DrawText(surface, collisionStatement)
+    def DrawTotalCollisions(self, surface, total_collisions):
+        collisionStatement = " Total Collisions: " + str(total_collisions) + "  "
+        textSurface = self.font.render(collisionStatement, 1, (200, 0, 0), (255,255,255)) # red text color, white background
+        surface.blit(textSurface, (0, 0)) # place the total number of collisions on the top left
 

--- a/ui.py
+++ b/ui.py
@@ -12,7 +12,8 @@ class UI:
         for player in game.players:
             # draw the player onto temp_surface
             self.gamedrawer.DrawPlayer(self.temp_surface,player,lerp_alpha)
-            self.gamedrawer.DrawTotalCollisions(player.name, self.temp_surface, player.total_collisions)
+            self.gamedrawer.DrawTotalCollisions(self.temp_surface, player.total_collisions)
+            self.gamedrawer.DrawPolicyName(self.temp_surface, player.name)
             # TODO: text for total collisions for the player
             #         consider using alpha transparency
             #       text for player.name


### PR DESCRIPTION
I added a "DrawPolicyName" function to blit the policy name. I placed it on the bottom left. I also removed the general "DrawText" function, and just blitted the two strings within their own functions, since they each have different locations (top left vs bottom left). Here's what it looks like:

<img width="1223" alt="Screen Shot 2020-11-28 at 8 42 02 PM" src="https://user-images.githubusercontent.com/19720593/100529934-2d61e300-31ba-11eb-9321-49aabf176dcc.png">
